### PR TITLE
Add theme and language settings

### DIFF
--- a/DebtTracker/ContentView.swift
+++ b/DebtTracker/ContentView.swift
@@ -2,19 +2,31 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var debtStore: DebtStore
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
+    
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
     
     var body: some View {
         TabView {
             DebtListView()
                 .tabItem {
                     Image(systemName: "list.bullet")
-                    Text("Debts")
+                    Text(localizedString("debts"))
                 }
             
             StatisticsView()
                 .tabItem {
                     Image(systemName: "chart.bar")
-                    Text("Statistics")
+                    Text(localizedString("statistics"))
+                }
+            
+            SettingsView()
+                .tabItem {
+                    Image(systemName: "gearshape.fill")
+                    Text(localizedString("settings"))
                 }
         }
         .accentColor(.blue)
@@ -23,6 +35,12 @@ struct ContentView: View {
 
 struct StatisticsView: View {
     @EnvironmentObject var debtStore: DebtStore
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
+    
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
     
     var body: some View {
         NavigationView {
@@ -31,21 +49,21 @@ struct StatisticsView: View {
                     // Summary Cards
                     VStack(spacing: 16) {
                         SummaryCard(
-                            title: "Owed to Me",
+                            title: localizedString("owed_to_me"),
                             amount: debtStore.totalOwedToMe,
                             color: .green,
                             icon: "arrow.down.circle.fill"
                         )
                         
                         SummaryCard(
-                            title: "I Owe",
+                            title: localizedString("i_owe"),
                             amount: debtStore.totalIOwe,
                             color: .red,
                             icon: "arrow.up.circle.fill"
                         )
                         
                         SummaryCard(
-                            title: "Net Balance",
+                            title: localizedString("net_balance"),
                             amount: debtStore.totalOwedToMe - debtStore.totalIOwe,
                             color: debtStore.totalOwedToMe >= debtStore.totalIOwe ? .green : .red,
                             icon: "equal.circle.fill"
@@ -59,7 +77,7 @@ struct StatisticsView: View {
                             HStack {
                                 Image(systemName: "exclamationmark.triangle.fill")
                                     .foregroundColor(.orange)
-                                Text("Overdue Debts")
+                                Text(localizedString("overdue_debts"))
                                     .font(.headline)
                                     .fontWeight(.semibold)
                             }
@@ -76,16 +94,16 @@ struct StatisticsView: View {
                     
                     // Quick Stats
                     VStack(alignment: .leading, spacing: 16) {
-                        Text("Quick Stats")
+                        Text(localizedString("quick_stats"))
                             .font(.headline)
                             .fontWeight(.semibold)
                         
                         HStack {
-                            StatItem(title: "Total Debts", value: "\(debtStore.debts.count)")
+                            StatItem(title: localizedString("total_debts"), value: "\(debtStore.debts.count)")
                             Spacer()
-                            StatItem(title: "Unpaid", value: "\(debtStore.unpaidDebts.count)")
+                            StatItem(title: localizedString("unpaid"), value: "\(debtStore.unpaidDebts.count)")
                             Spacer()
-                            StatItem(title: "Paid", value: "\(debtStore.paidDebts.count)")
+                            StatItem(title: localizedString("paid"), value: "\(debtStore.paidDebts.count)")
                         }
                     }
                     .padding()
@@ -95,7 +113,7 @@ struct StatisticsView: View {
                 }
                 .padding(.vertical)
             }
-            .navigationTitle("Statistics")
+            .navigationTitle(localizedString("statistics"))
         }
     }
 }
@@ -139,6 +157,12 @@ struct SummaryCard: View {
 
 struct OverdueDebtRow: View {
     let debt: Debt
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
+    
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
     
     var body: some View {
         HStack {
@@ -160,7 +184,7 @@ struct OverdueDebtRow: View {
                     .foregroundColor(debt.isOwedToMe ? .green : .red)
                 
                 if let days = debt.remainingDays {
-                    Text("\(abs(days)) days overdue")
+                    Text("\(abs(days)) \(localizedString("days_overdue"))")
                         .font(.caption)
                         .foregroundColor(.orange)
                 }
@@ -189,4 +213,5 @@ struct StatItem: View {
 #Preview {
     ContentView()
         .environmentObject(DebtStore())
+        .environmentObject(UserSettings())
 }

--- a/DebtTracker/DebtListView.swift
+++ b/DebtTracker/DebtListView.swift
@@ -2,25 +2,39 @@ import SwiftUI
 
 struct DebtListView: View {
     @EnvironmentObject var debtStore: DebtStore
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
     @State private var showingAddDebt = false
     @State private var filterOption: FilterOption = .all
     @State private var sortOption: SortOption = .dateCreated
     @State private var searchText = ""
     
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
+    
     enum FilterOption: String, CaseIterable {
-        case all = "All"
-        case owedToMe = "Owed to Me"
-        case iOwe = "I Owe"
-        case unpaid = "Unpaid"
-        case paid = "Paid"
-        case overdue = "Overdue"
+        case all = "all"
+        case owedToMe = "owed_to_me_filter"
+        case iOwe = "i_owe_filter"
+        case unpaid = "unpaid_filter"
+        case paid = "paid_filter"
+        case overdue = "overdue_filter"
+        
+        func localizedName(for language: UserSettings.AppLanguage) -> String {
+            return LocalizationHelper.shared.localizedString(self.rawValue, language: language)
+        }
     }
     
     enum SortOption: String, CaseIterable {
-        case dateCreated = "Date Created"
-        case amount = "Amount"
-        case dueDate = "Due Date"
-        case title = "Title"
+        case dateCreated = "date_created"
+        case amount = "amount"
+        case dueDate = "due_date"
+        case title = "title"
+        
+        func localizedName(for language: UserSettings.AppLanguage) -> String {
+            return LocalizationHelper.shared.localizedString(self.rawValue, language: language)
+        }
     }
     
     private var filteredAndSortedDebts: [Debt] {
@@ -79,13 +93,13 @@ struct DebtListView: View {
                     HStack {
                         Menu {
                             ForEach(FilterOption.allCases, id: \.self) { option in
-                                Button(option.rawValue) {
+                                Button(option.localizedName(for: userSettings.selectedLanguage)) {
                                     filterOption = option
                                 }
                             }
                         } label: {
                             HStack {
-                                Text("Filter: \(filterOption.rawValue)")
+                                Text("\(localizedString("filter")): \(filterOption.localizedName(for: userSettings.selectedLanguage))")
                                 Image(systemName: "chevron.down")
                             }
                             .padding(.horizontal, 12)
@@ -98,13 +112,13 @@ struct DebtListView: View {
                         
                         Menu {
                             ForEach(SortOption.allCases, id: \.self) { option in
-                                Button(option.rawValue) {
+                                Button(option.localizedName(for: userSettings.selectedLanguage)) {
                                     sortOption = option
                                 }
                             }
                         } label: {
                             HStack {
-                                Text("Sort: \(sortOption.rawValue)")
+                                Text("\(localizedString("sort")): \(sortOption.localizedName(for: userSettings.selectedLanguage))")
                                 Image(systemName: "chevron.down")
                             }
                             .padding(.horizontal, 12)
@@ -132,8 +146,8 @@ struct DebtListView: View {
                     .listStyle(PlainListStyle())
                 }
             }
-            .navigationTitle("Debt Tracker")
-            .searchable(text: $searchText, prompt: "Search debts...")
+            .navigationTitle(localizedString("debt_tracker"))
+            .searchable(text: $searchText, prompt: localizedString("search_debts"))
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showingAddDebt = true }) {
@@ -157,6 +171,12 @@ struct DebtListView: View {
 struct DebtRowView: View {
     let debt: Debt
     @EnvironmentObject var debtStore: DebtStore
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
+    
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
     
     var body: some View {
         HStack {
@@ -165,7 +185,7 @@ struct DebtRowView: View {
                     .font(.headline)
                     .foregroundColor(debt.isPaid ? .secondary : .primary)
                 
-                Text(debt.isOwedToMe ? "From: \(debt.debtor)" : "To: \(debt.creditor)")
+                Text(debt.isOwedToMe ? "\(localizedString("from")): \(debt.debtor)" : "\(localizedString("to")): \(debt.creditor)")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                 
@@ -177,7 +197,7 @@ struct DebtRowView: View {
                             .font(.caption)
                         
                         if debt.isOverdue {
-                            Text("(Overdue)")
+                            Text(localizedString("overdue"))
                                 .font(.caption)
                                 .foregroundColor(.red)
                         }
@@ -197,7 +217,7 @@ struct DebtRowView: View {
                     if debt.isPaid {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(.green)
-                        Text("Paid")
+                        Text(localizedString("paid"))
                             .font(.caption)
                             .foregroundColor(.green)
                     } else {
@@ -217,6 +237,12 @@ struct DebtRowView: View {
 
 struct EmptyStateView: View {
     let filterOption: DebtListView.FilterOption
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
+    
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
     
     var body: some View {
         VStack(spacing: 16) {
@@ -237,17 +263,17 @@ struct EmptyStateView: View {
     private var emptyMessage: String {
         switch filterOption {
         case .all:
-            return "No debts found.\nTap + to add your first debt."
+            return localizedString("no_debts_found")
         case .owedToMe:
-            return "No one owes you money.\nLucky you!"
+            return localizedString("no_one_owes_you")
         case .iOwe:
-            return "You don't owe anyone money.\nGreat job!"
+            return localizedString("you_dont_owe")
         case .unpaid:
-            return "No unpaid debts found."
+            return localizedString("no_unpaid_debts")
         case .paid:
-            return "No paid debts found."
+            return localizedString("no_paid_debts")
         case .overdue:
-            return "No overdue debts.\nEverything is on track!"
+            return localizedString("no_overdue_debts")
         }
     }
 }
@@ -255,4 +281,5 @@ struct EmptyStateView: View {
 #Preview {
     DebtListView()
         .environmentObject(DebtStore())
+        .environmentObject(UserSettings())
 }

--- a/DebtTracker/DebtTrackerApp.swift
+++ b/DebtTracker/DebtTrackerApp.swift
@@ -3,11 +3,14 @@ import SwiftUI
 @main
 struct DebtTrackerApp: App {
     @StateObject private var debtStore = DebtStore()
+    @StateObject private var userSettings = UserSettings()
     
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(debtStore)
+                .environmentObject(userSettings)
+                .preferredColorScheme(userSettings.selectedTheme.colorScheme)
         }
     }
 }

--- a/DebtTracker/LocalizationHelper.swift
+++ b/DebtTracker/LocalizationHelper.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+class LocalizationHelper: ObservableObject {
+    static let shared = LocalizationHelper()
+    
+    private init() {}
+    
+    func localizedString(_ key: String, language: UserSettings.AppLanguage) -> String {
+        switch language {
+        case .english:
+            return englishStrings[key] ?? key
+        case .russian:
+            return russianStrings[key] ?? key
+        }
+    }
+    
+    private let englishStrings: [String: String] = [
+        // Tab Items
+        "debts": "Debts",
+        "statistics": "Statistics",
+        "settings": "Settings",
+        
+        // Main Navigation
+        "debt_tracker": "Debt Tracker",
+        "add_debt": "Add Debt",
+        
+        // Settings
+        "theme": "Theme",
+        "language": "Language",
+        "appearance": "Appearance",
+        "general": "General",
+        
+        // Statistics
+        "owed_to_me": "Owed to Me",
+        "i_owe": "I Owe",
+        "net_balance": "Net Balance",
+        "overdue_debts": "Overdue Debts",
+        "quick_stats": "Quick Stats",
+        "total_debts": "Total Debts",
+        "unpaid": "Unpaid",
+        "paid": "Paid",
+        
+        // Filters
+        "all": "All",
+        "owed_to_me_filter": "Owed to Me",
+        "i_owe_filter": "I Owe",
+        "unpaid_filter": "Unpaid",
+        "paid_filter": "Paid",
+        "overdue_filter": "Overdue",
+        
+        // Sort Options
+        "date_created": "Date Created",
+        "amount": "Amount",
+        "due_date": "Due Date",
+        "title": "Title",
+        
+        // Common
+        "filter": "Filter",
+        "sort": "Sort",
+        "search_debts": "Search debts...",
+        "from": "From",
+        "to": "To",
+        "overdue": "(Overdue)",
+        "days_overdue": "days overdue",
+        
+        // Empty States
+        "no_debts_found": "No debts found.\nTap + to add your first debt.",
+        "no_one_owes_you": "No one owes you money.\nLucky you!",
+        "you_dont_owe": "You don't owe anyone money.\nGreat job!",
+        "no_unpaid_debts": "No unpaid debts found.",
+        "no_paid_debts": "No paid debts found.",
+        "no_overdue_debts": "No overdue debts.\nEverything is on track!"
+    ]
+    
+    private let russianStrings: [String: String] = [
+        // Tab Items
+        "debts": "Долги",
+        "statistics": "Статистика",
+        "settings": "Настройки",
+        
+        // Main Navigation
+        "debt_tracker": "Учёт Долгов",
+        "add_debt": "Добавить Долг",
+        
+        // Settings
+        "theme": "Тема",
+        "language": "Язык",
+        "appearance": "Внешний вид",
+        "general": "Общие",
+        
+        // Statistics
+        "owed_to_me": "Мне должны",
+        "i_owe": "Я должен",
+        "net_balance": "Чистый баланс",
+        "overdue_debts": "Просроченные долги",
+        "quick_stats": "Быстрая статистика",
+        "total_debts": "Всего долгов",
+        "unpaid": "Неоплачено",
+        "paid": "Оплачено",
+        
+        // Filters
+        "all": "Все",
+        "owed_to_me_filter": "Мне должны",
+        "i_owe_filter": "Я должен",
+        "unpaid_filter": "Неоплачено",
+        "paid_filter": "Оплачено",
+        "overdue_filter": "Просрочено",
+        
+        // Sort Options
+        "date_created": "Дата создания",
+        "amount": "Сумма",
+        "due_date": "Срок оплаты",
+        "title": "Название",
+        
+        // Common
+        "filter": "Фильтр",
+        "sort": "Сортировка",
+        "search_debts": "Поиск долгов...",
+        "from": "От",
+        "to": "Кому",
+        "overdue": "(Просрочено)",
+        "days_overdue": "дней просрочки",
+        
+        // Empty States
+        "no_debts_found": "Долги не найдены.\nНажмите + чтобы добавить первый долг.",
+        "no_one_owes_you": "Никто вам не должен.\nВезёт!",
+        "you_dont_owe": "Вы никому не должны.\nОтличная работа!",
+        "no_unpaid_debts": "Неоплаченные долги не найдены.",
+        "no_paid_debts": "Оплаченные долги не найдены.",
+        "no_overdue_debts": "Нет просроченных долгов.\nВсё идёт по плану!"
+    ]
+}

--- a/DebtTracker/SettingsView.swift
+++ b/DebtTracker/SettingsView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var userSettings: UserSettings
+    @ObservedObject private var localizationHelper = LocalizationHelper.shared
+    
+    private func localizedString(_ key: String) -> String {
+        return localizationHelper.localizedString(key, language: userSettings.selectedLanguage)
+    }
+    
+    var body: some View {
+        NavigationView {
+            List {
+                // Appearance Section
+                Section {
+                    // Theme Selection
+                    HStack {
+                        Image(systemName: "paintbrush.fill")
+                            .foregroundColor(.blue)
+                            .frame(width: 24)
+                        
+                        Text(localizedString("theme"))
+                            .font(.body)
+                        
+                        Spacer()
+                        
+                        Menu {
+                            ForEach(UserSettings.AppTheme.allCases, id: \.self) { theme in
+                                Button(action: {
+                                    userSettings.updateTheme(theme)
+                                }) {
+                                    HStack {
+                                        Text(theme.localizedName(for: userSettings.selectedLanguage))
+                                        if userSettings.selectedTheme == theme {
+                                            Image(systemName: "checkmark")
+                                        }
+                                    }
+                                }
+                            }
+                        } label: {
+                            HStack {
+                                Text(userSettings.selectedTheme.localizedName(for: userSettings.selectedLanguage))
+                                    .foregroundColor(.secondary)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .foregroundColor(.secondary)
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text(localizedString("appearance"))
+                }
+                
+                // General Section
+                Section {
+                    // Language Selection
+                    HStack {
+                        Image(systemName: "globe")
+                            .foregroundColor(.green)
+                            .frame(width: 24)
+                        
+                        Text(localizedString("language"))
+                            .font(.body)
+                        
+                        Spacer()
+                        
+                        Menu {
+                            ForEach(UserSettings.AppLanguage.allCases, id: \.self) { language in
+                                Button(action: {
+                                    userSettings.updateLanguage(language)
+                                }) {
+                                    HStack {
+                                        Text(language.localizedName)
+                                        if userSettings.selectedLanguage == language {
+                                            Image(systemName: "checkmark")
+                                        }
+                                    }
+                                }
+                            }
+                        } label: {
+                            HStack {
+                                Text(userSettings.selectedLanguage.localizedName)
+                                    .foregroundColor(.secondary)
+                                Image(systemName: "chevron.up.chevron.down")
+                                    .foregroundColor(.secondary)
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text(localizedString("general"))
+                }
+                
+                // Theme Preview Section
+                Section {
+                    VStack(spacing: 16) {
+                        // Theme preview card
+                        HStack {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(localizedString("debt_tracker"))
+                                    .font(.headline)
+                                    .fontWeight(.semibold)
+                                
+                                Text(localizedString("owed_to_me"))
+                                    .font(.subheadline)
+                                    .foregroundColor(.green)
+                                
+                                Text(localizedString("i_owe"))
+                                    .font(.subheadline)
+                                    .foregroundColor(.red)
+                            }
+                            
+                            Spacer()
+                            
+                            VStack(alignment: .trailing, spacing: 8) {
+                                Text("$1,250.00")
+                                    .font(.headline)
+                                    .foregroundColor(.green)
+                                
+                                Text("$500.00")
+                                    .font(.headline)
+                                    .foregroundColor(.red)
+                            }
+                        }
+                        .padding()
+                        .background(Color(.systemGray6))
+                        .cornerRadius(12)
+                    }
+                } header: {
+                    Text("Preview")
+                }
+            }
+            .navigationTitle(localizedString("settings"))
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environmentObject(UserSettings())
+}

--- a/DebtTracker/UserSettings.swift
+++ b/DebtTracker/UserSettings.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import Foundation
+
+class UserSettings: ObservableObject {
+    @Published var selectedTheme: AppTheme = .system
+    @Published var selectedLanguage: AppLanguage = .english
+    
+    enum AppTheme: String, CaseIterable {
+        case light = "light"
+        case dark = "dark"
+        case system = "system"
+        
+        var colorScheme: ColorScheme? {
+            switch self {
+            case .light:
+                return .light
+            case .dark:
+                return .dark
+            case .system:
+                return nil
+            }
+        }
+        
+        func localizedName(for language: AppLanguage) -> String {
+            switch self {
+            case .light:
+                return language == .english ? "Light" : "Светлая"
+            case .dark:
+                return language == .english ? "Dark" : "Тёмная"
+            case .system:
+                return language == .english ? "System" : "Системная"
+            }
+        }
+    }
+    
+    enum AppLanguage: String, CaseIterable {
+        case english = "en"
+        case russian = "ru"
+        
+        var localizedName: String {
+            switch self {
+            case .english:
+                return "English"
+            case .russian:
+                return "Русский"
+            }
+        }
+        
+        var locale: Locale {
+            return Locale(identifier: rawValue)
+        }
+    }
+    
+    private let themeKey = "selectedTheme"
+    private let languageKey = "selectedLanguage"
+    
+    init() {
+        loadSettings()
+    }
+    
+    private func loadSettings() {
+        if let themeString = UserDefaults.standard.string(forKey: themeKey),
+           let theme = AppTheme(rawValue: themeString) {
+            selectedTheme = theme
+        }
+        
+        if let languageString = UserDefaults.standard.string(forKey: languageKey),
+           let language = AppLanguage(rawValue: languageString) {
+            selectedLanguage = language
+        }
+    }
+    
+    func saveSettings() {
+        UserDefaults.standard.set(selectedTheme.rawValue, forKey: themeKey)
+        UserDefaults.standard.set(selectedLanguage.rawValue, forKey: languageKey)
+    }
+    
+    func updateTheme(_ theme: AppTheme) {
+        selectedTheme = theme
+        saveSettings()
+    }
+    
+    func updateLanguage(_ language: AppLanguage) {
+        selectedLanguage = language
+        saveSettings()
+    }
+}


### PR DESCRIPTION
Add comprehensive settings for theme and language selection (English/Russian).

This PR introduces a new 'Settings' tab, enabling users to customize the app's appearance (Light, Dark, System themes) and switch between English and Russian languages. All relevant UI elements have been localized to support dynamic language changes.