### PR TITLE
Display name on main and statistics screens

### DIFF
--- a/DebtTracker/ContentView.swift
+++ b/DebtTracker/ContentView.swift
@@ -113,7 +113,7 @@ struct StatisticsView: View {
                 }
                 .padding(.vertical)
             }
-            .navigationTitle(localizedString("statistics"))
+            .navigationTitle(localizedString("debt_tracker"))
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {


### PR DESCRIPTION
Update the Statistics screen's navigation title to consistently display the app name.