### PR TITLE
Rename statistics window

### DIFF
--- a/DebtTracker/ContentView.swift
+++ b/DebtTracker/ContentView.swift
@@ -113,7 +113,7 @@ struct StatisticsView: View {
                 }
                 .padding(.vertical)
             }
-            .navigationTitle(localizedString("debt_tracker"))
+            .navigationTitle(localizedString("statistics"))
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {


### PR DESCRIPTION
Rename the navigation title on the Statistics tab from 'Debt Tracker' to 'Statistics'.