### PR TITLE
Fix identified software bug

### DIFF
--- a/DebtTracker/Debt.swift
+++ b/DebtTracker/Debt.swift
@@ -66,7 +66,7 @@ struct Debt: Identifiable, Codable {
     
     // Urgency level based on due date
     var urgencyLevel: UrgencyLevel {
-        guard let dueDate = dueDate, !isPaid else { return .normal }
+        guard dueDate != nil, !isPaid else { return .normal }
         let daysRemaining = remainingDays ?? 0
         
         if daysRemaining < 0 {


### PR DESCRIPTION
Remove unused optional binding in `Debt.urgencyLevel` guard statement.

The `dueDate` was already handled by `remainingDays`, making the optional binding in the guard statement redundant and causing an 'immutable value never used' warning.