### PR TITLE
Address software issues

### DIFF
--- a/DebtTracker/ContentView.swift
+++ b/DebtTracker/ContentView.swift
@@ -223,8 +223,10 @@ struct StatItem: View {
     }
 }
 
-#Preview {
-    ContentView()
-        .environmentObject(DebtStore())
-        .environmentObject(UserSettings())
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(DebtStore())
+            .environmentObject(UserSettings())
+    }
 }

--- a/DebtTracker/PaymentProgressBar.swift
+++ b/DebtTracker/PaymentProgressBar.swift
@@ -71,14 +71,14 @@ struct PaymentProgressView: View {
     }
 }
 
-#if swift(>=5.9)
-#Preview {
-    VStack(spacing: 20) {
-        PaymentProgressBar(progress: 0.25)
-        PaymentProgressBar(progress: 0.5)
-        PaymentProgressBar(progress: 0.75)
-        PaymentProgressBar(progress: 1.0)
+struct PaymentProgressBar_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            PaymentProgressBar(progress: 0.25)
+            PaymentProgressBar(progress: 0.5)
+            PaymentProgressBar(progress: 0.75)
+            PaymentProgressBar(progress: 1.0)
+        }
+        .padding()
     }
-    .padding()
 }
-#endif

--- a/DebtTracker/SettingsView.swift
+++ b/DebtTracker/SettingsView.swift
@@ -114,9 +114,9 @@ struct SettingsView: View {
     }
 }
 
-#if swift(>=5.9)
-#Preview {
-    SettingsView()
-        .environmentObject(UserSettings())
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+            .environmentObject(UserSettings())
+    }
 }
-#endif


### PR DESCRIPTION
Refactor SwiftUI previews from `#Preview` macro to `PreviewProvider` to fix build errors and ensure compatibility with earlier Swift/SwiftUI versions.

The `#Preview` macro, introduced in Swift 5.9, caused 'buildExpression' errors and missing environment object issues in environments not supporting it. This change reverts to the traditional `PreviewProvider` struct for broader compatibility.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7b8a3ea2-e132-41a2-a1be-e640efc5a57b) · [Cursor](https://cursor.com/background-agent?bcId=bc-7b8a3ea2-e132-41a2-a1be-e640efc5a57b)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)