### PR TITLE
Fix codebase issue

### DIFF
--- a/DebtTracker/PaymentProgressBar.swift
+++ b/DebtTracker/PaymentProgressBar.swift
@@ -44,6 +44,15 @@ struct PaymentProgressView: View {
     let debt: Debt
     @EnvironmentObject var userSettings: UserSettings
     
+    private var totalPaidFormatted: String {
+        let totalPaid = debt.partialPayments.reduce(0) { $0 + $1.amount }
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = debt.currency
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: totalPaid)) ?? "\(Int(totalPaid)) \(debt.currencySymbol)"
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
@@ -54,12 +63,6 @@ struct PaymentProgressView: View {
                 Spacer()
                 
                 if !userSettings.hideTotalAmount {
-                    let totalPaid = debt.partialPayments.reduce(0) { $0 + $1.amount }
-                    let formatter = NumberFormatter()
-                    formatter.numberStyle = .currency
-                    formatter.currencyCode = debt.currency
-                    formatter.maximumFractionDigits = 0
-                    let totalPaidFormatted = formatter.string(from: NSNumber(value: totalPaid)) ?? "\(Int(totalPaid)) \(debt.currencySymbol)"
                     Text("\(totalPaidFormatted) / \(debt.formattedAmount)")
                         .font(.caption)
                         .foregroundColor(.secondary)


### PR DESCRIPTION
Refactor SwiftUI view by moving variable declarations out of conditional block.

This change resolves "buildExpression is unavailable" compilation errors, as SwiftUI's `ViewBuilder` does not permit variable declarations directly within its view hierarchy. Variables are now defined in a computed property outside the `body`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-10f7ed13-a75e-46ca-9f0f-2a85e8c8986a) · [Cursor](https://cursor.com/background-agent?bcId=bc-10f7ed13-a75e-46ca-9f0f-2a85e8c8986a)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)